### PR TITLE
Release/2.3.0

### DIFF
--- a/.github/workflows/dev_build.yml
+++ b/.github/workflows/dev_build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.22.1"
+          flutter-version: "3.22.2"
           channel: 'stable'
           cache: true
 

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.22.1"
+          flutter-version: "3.22.2"
           channel: 'stable'
           cache: true
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <application
         android:label="GlassDown"
         android:name="${applicationName}"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,5 +35,12 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <provider
+            android:name="rikka.shizuku.ShizukuProvider"
+            android:authorities="${applicationId}.shizuku"
+            android:multiprocess="false"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
-    <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
     <application
         android:label="GlassDown"
         android:name="${applicationName}"

--- a/lib/services/scraper_service.dart
+++ b/lib/services/scraper_service.dart
@@ -127,7 +127,7 @@ class ScraperService with ListenableServiceMixin {
         final name = _trimAppName(textElement.text);
         final link = textElement.attributes['href'];
 
-        if (!appNames.contains(name)) {
+        if (!appNames.contains(name) && !name.contains('beta')) {
           searchResults.add((
             imgLink: 'https://www.apkmirror.com$logoUrl',
             name: name,

--- a/lib/services/scraper_service.dart
+++ b/lib/services/scraper_service.dart
@@ -9,6 +9,7 @@ import 'package:glass_down_v2/util/function_name.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:glass_down_v2/models/errors/scrape_error.dart';
 import 'package:flutter_logs/flutter_logs.dart';
+import 'package:intl/intl.dart';
 import 'package:stacked/stacked.dart';
 
 typedef ApkTypeRecord = (String link, String arch);
@@ -640,9 +641,16 @@ class ScraperService with ListenableServiceMixin {
 
       final extension = app.pickedType!.isBundle ? 'apkm' : 'apk';
 
-      final file = File(
-        '${savePlace.path}/$name.$extension',
-      );
+      final finalPath = '${savePlace.path}/$name.$extension';
+      final exists = await File(finalPath).exists();
+
+      File file;
+      if (!exists) {
+        file = File(finalPath);
+      } else {
+        final date = DateFormat('HH_mm_ss').format(DateTime.now());
+        file = File('${savePlace.path}/${name}_$date.$extension');
+      }
       FlutterLogs.logInfo(
         runtimeType.toString(),
         getFunctionName(),

--- a/lib/services/scraper_service.dart
+++ b/lib/services/scraper_service.dart
@@ -89,10 +89,13 @@ class ScraperService with ListenableServiceMixin {
 
   final _dio = Dio(
     BaseOptions(
-      baseUrl: 'https://www.apkmirror.com/',
-      followRedirects: true,
-      method: 'get',
-    ),
+        baseUrl: 'https://www.apkmirror.com/',
+        followRedirects: true,
+        method: 'get',
+        headers: {
+          HttpHeaders.userAgentHeader:
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36 Edg/127.0.0.0',
+        }),
   );
 
   Future<List<SearchResult>> getAppSearch(String search) async {

--- a/lib/services/scraper_service.dart
+++ b/lib/services/scraper_service.dart
@@ -89,13 +89,14 @@ class ScraperService with ListenableServiceMixin {
 
   final _dio = Dio(
     BaseOptions(
-        baseUrl: 'https://www.apkmirror.com/',
-        followRedirects: true,
-        method: 'get',
-        headers: {
-          HttpHeaders.userAgentHeader:
-              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36 Edg/127.0.0.0',
-        }),
+      baseUrl: 'https://www.apkmirror.com/',
+      followRedirects: true,
+      method: 'get',
+      headers: {
+        HttpHeaders.userAgentHeader:
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36 Edg/127.0.0.0',
+      },
+    ),
   );
 
   Future<List<SearchResult>> getAppSearch(String search) async {

--- a/lib/services/scraper_service.dart
+++ b/lib/services/scraper_service.dart
@@ -15,6 +15,8 @@ typedef ApkTypeRecord = (String link, String arch);
 
 typedef Status = (bool? status, String? message);
 
+typedef StatusWithUri = (bool? status, String? message, Uri? uri);
+
 typedef SearchResult = ({String imgLink, String name, String link});
 
 class ScraperService with ListenableServiceMixin {
@@ -36,20 +38,20 @@ class ScraperService with ListenableServiceMixin {
   Status _linkStatus = (null, null);
   Status _apkStatus = (null, null);
   double? _downloadProgress;
-  Status _saveStatus = (null, null);
+  StatusWithUri _saveStatus = (null, null, null);
 
   Status get pageStatus => _pageStatus;
   Status get linkStatus => _linkStatus;
   Status get apkStatus => _apkStatus;
   double? get downloadProgress => _downloadProgress;
-  Status get saveStatus => _saveStatus;
+  StatusWithUri get saveStatus => _saveStatus;
 
   void clearStatuses() {
     _pageStatus = (null, null);
     _linkStatus = (null, null);
     _apkStatus = (null, null);
     _downloadProgress = null;
-    _saveStatus = (null, null);
+    _saveStatus = (null, null, null);
   }
 
   String _getErrorMessage(dynamic e) {
@@ -643,7 +645,7 @@ class ScraperService with ListenableServiceMixin {
         'Saving to: ${file.path}',
       );
 
-      _saveStatus = (true, file.path);
+      _saveStatus = (true, file.path, file.uri);
 
       return file.path;
     } catch (e) {
@@ -652,7 +654,7 @@ class ScraperService with ListenableServiceMixin {
         getFunctionName(),
         e is DioException ? e.message ?? e.error.toString() : e.toString(),
       );
-      _saveStatus = (false, _getErrorMessage(e));
+      _saveStatus = (false, _getErrorMessage(e), null);
       _apkStatus = (false, _getErrorMessage(e));
       rethrow;
     } finally {
@@ -691,7 +693,7 @@ class ScraperService with ListenableServiceMixin {
         message,
       );
       if (_saveStatus.$1 == null) {
-        _saveStatus = (false, _getErrorMessage(e));
+        _saveStatus = (false, _getErrorMessage(e), null);
       }
       _apkStatus = (false, _getErrorMessage(e));
       rethrow;

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -2,8 +2,11 @@ import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_logs/flutter_logs.dart';
 import 'package:glass_down_v2/services/custom_themes_service.dart';
+import 'package:glass_down_v2/util/function_name.dart';
 import 'package:package_info_plus/package_info_plus.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked/stacked_annotations.dart';
@@ -276,5 +279,26 @@ class SettingsService
   Future<int> getSdkVersion() async {
     final deviceInfo = await DeviceInfoPlugin().androidInfo;
     return deviceInfo.version.sdkInt;
+  }
+
+  Future<bool> storageGranted() async {
+    try {
+      final sdk = await getSdkVersion();
+      bool storageGranted = false;
+      if (sdk >= 30) {
+        storageGranted =
+            await Permission.manageExternalStorage.status.isGranted;
+      } else {
+        storageGranted = await Permission.storage.status.isGranted;
+      }
+      return storageGranted;
+    } catch (e) {
+      FlutterLogs.logError(
+        runtimeType.toString(),
+        getFunctionName(),
+        'Cannot write to this folder',
+      );
+    }
+    return false;
   }
 }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -338,7 +338,12 @@ class SettingsService
     return false;
   }
 
-  Future<String?> checkShizukuStatus() async {
-    return await ShizukuApkInstaller.checkPermission();
+  Future<bool> shizukuAvailable() async {
+    final status = await ShizukuApkInstaller.checkPermission();
+    final granted = status?.contains('granted');
+    if (granted != null && _shizuku) {
+      return true;
+    }
+    return false;
   }
 }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -8,6 +8,7 @@ import 'package:glass_down_v2/util/function_name.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shizuku_apk_installer/shizuku_apk_installer.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked/stacked_annotations.dart';
 
@@ -335,5 +336,9 @@ class SettingsService
       );
     }
     return false;
+  }
+
+  Future<String?> checkShizukuStatus() async {
+    return await ShizukuApkInstaller.checkPermission();
   }
 }

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -257,7 +257,8 @@ class SettingsService
         _prefs.getBool(SettingsKey.useImportedFont.name) ?? _useImportedFont;
     _customFont = _prefs.getString(SettingsKey.customFont.name) ?? _customFont;
     _shizuku = _prefs.getBool(SettingsKey.shizuku.name) ?? _shizuku;
-    _shownPermissions = _prefs.getBool(SettingsKey.shownPermissions.name) ?? _shownPermissions;
+    _shownPermissions =
+        _prefs.getBool(SettingsKey.shownPermissions.name) ?? _shownPermissions;
   }
 
   Future<void> ensureAppDirExists() async {
@@ -313,6 +314,19 @@ class SettingsService
         storageGranted = await Permission.storage.status.isGranted;
       }
       return storageGranted;
+    } catch (e) {
+      FlutterLogs.logError(
+        runtimeType.toString(),
+        getFunctionName(),
+        'Cannot write to this folder',
+      );
+    }
+    return false;
+  }
+
+  Future<bool> installGranted() async {
+    try {
+      return await Permission.requestInstallPackages.status.isGranted;
     } catch (e) {
       FlutterLogs.logError(
         runtimeType.toString(),

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -57,6 +57,7 @@ class SettingsService
       _autoRemove,
       _offerRemoval,
       _exportLogsPath,
+      _shizuku,
     ]);
   }
 
@@ -190,6 +191,14 @@ class SettingsService
     notifyListeners();
   }
 
+  bool _shizuku = false;
+  bool get shizuku => _shizuku;
+  void setShizuku(bool val) {
+    _shizuku = val;
+    notifyListeners();
+    _savePref<bool>(SettingsKey.shizuku, val);
+  }
+
   @override
   Future<void> init() async {
     _prefs = await SharedPreferences.getInstance();
@@ -237,6 +246,7 @@ class SettingsService
     _useImportedFont =
         _prefs.getBool(SettingsKey.useImportedFont.name) ?? _useImportedFont;
     _customFont = _prefs.getString(SettingsKey.customFont.name) ?? _customFont;
+    _shizuku = _prefs.getBool(SettingsKey.shizuku.name) ?? _shizuku;
   }
 
   Future<void> ensureAppDirExists() async {

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -29,6 +29,7 @@ enum SettingsKey {
   useImportedFont,
   customFont,
   shizuku,
+  shownPermissions,
 }
 
 // ignore: constant_identifier_names
@@ -58,6 +59,7 @@ class SettingsService
       _offerRemoval,
       _exportLogsPath,
       _shizuku,
+      _shownPermissions,
     ]);
   }
 
@@ -199,6 +201,14 @@ class SettingsService
     _savePref<bool>(SettingsKey.shizuku, val);
   }
 
+  bool _shownPermissions = false;
+  bool get shownPermissions => _shownPermissions;
+  void setShownPermissions(bool val) {
+    _shownPermissions = val;
+    notifyListeners();
+    _savePref<bool>(SettingsKey.shownPermissions, val);
+  }
+
   @override
   Future<void> init() async {
     _prefs = await SharedPreferences.getInstance();
@@ -247,6 +257,7 @@ class SettingsService
         _prefs.getBool(SettingsKey.useImportedFont.name) ?? _useImportedFont;
     _customFont = _prefs.getString(SettingsKey.customFont.name) ?? _customFont;
     _shizuku = _prefs.getBool(SettingsKey.shizuku.name) ?? _shizuku;
+    _shownPermissions = _prefs.getBool(SettingsKey.shownPermissions.name) ?? _shownPermissions;
   }
 
   Future<void> ensureAppDirExists() async {

--- a/lib/services/updater_service.dart
+++ b/lib/services/updater_service.dart
@@ -61,7 +61,11 @@ class UpdaterService with ListenableServiceMixin {
       raf.writeFromSync(app.data!);
       raf.closeSync();
 
-      final shizukuAvailable = await _settings.shizukuAvailable();
+      final shizukuAllowed = _settings.shizuku;
+      bool shizukuAvailable = false;
+      if (shizukuAllowed) {
+        shizukuAvailable = await _settings.shizukuAvailable();
+      }
       if (shizukuAvailable) {
         await ShizukuApkInstaller.installAPK(
           file.uri.toString(),

--- a/lib/services/updater_service.dart
+++ b/lib/services/updater_service.dart
@@ -68,7 +68,7 @@ class UpdaterService with ListenableServiceMixin {
       final shizukuAvailable = await _settings.checkShizukuStatus();
       final granted = shizukuAvailable?.contains('granted');
       if (granted != null && _settings.shizuku) {
-        await ShizukuApkInstaller.installAPK(file.path, 'GlassDown');
+        await ShizukuApkInstaller.installAPK(file.uri.toString(), 'GlassDown');
       }
       OpenFilex.open(file.path);
     } catch (e) {

--- a/lib/services/updater_service.dart
+++ b/lib/services/updater_service.dart
@@ -10,7 +10,6 @@ import 'package:glass_down_v2/services/settings_service.dart';
 import 'package:glass_down_v2/util/function_name.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:package_info_plus/package_info_plus.dart';
-import 'package:shizuku_apk_installer/shizuku_apk_installer.dart';
 import 'package:stacked/stacked.dart';
 
 class UpdaterService with ListenableServiceMixin {
@@ -58,20 +57,8 @@ class UpdaterService with ListenableServiceMixin {
 
       final raf = file.openSync(mode: FileMode.writeOnly);
 
-      raf.writeFromSync(app.data!);
-      raf.closeSync();
-
-      final shizukuAllowed = _settings.shizuku;
-      bool shizukuAvailable = false;
-      if (shizukuAllowed) {
-        shizukuAvailable = await _settings.shizukuAvailable();
-      }
-      if (shizukuAvailable) {
-        await ShizukuApkInstaller.installAPK(
-          file.uri.toString(),
-          'com.sinneida.glassdown2',
-        );
-      }
+      await raf.writeFrom(app.data!);
+      await raf.close();
 
       final installGranted = await _settings.installGranted();
       if (installGranted) {

--- a/lib/services/updater_service.dart
+++ b/lib/services/updater_service.dart
@@ -65,10 +65,12 @@ class UpdaterService with ListenableServiceMixin {
       raf.writeFromSync(app.data!);
       raf.closeSync();
 
-      final shizukuAvailable = await _settings.checkShizukuStatus();
-      final granted = shizukuAvailable?.contains('granted');
-      if (granted != null && _settings.shizuku) {
-        await ShizukuApkInstaller.installAPK(file.uri.toString(), 'GlassDown');
+      final shizukuAvailable = await _settings.shizukuAvailable();
+      if (shizukuAvailable) {
+        await ShizukuApkInstaller.installAPK(
+          file.uri.toString(),
+          'com.sinneida.glassdown2',
+        );
       }
       OpenFilex.open(file.path);
     } catch (e) {

--- a/lib/ui/bottom_sheets/quick_settings/quick_settings.dart
+++ b/lib/ui/bottom_sheets/quick_settings/quick_settings.dart
@@ -6,6 +6,7 @@ import 'package:glass_down_v2/ui/views/settings/items/exclude_bundles/exclude_bu
 import 'package:glass_down_v2/ui/views/settings/items/exclude_unstable/exclude_unstable.dart';
 import 'package:glass_down_v2/ui/views/settings/items/offer_deleting_old_apks/offer_deleting_old_apks.dart';
 import 'package:glass_down_v2/ui/views/settings/items/pages_count/pages_count.dart';
+import 'package:glass_down_v2/ui/views/settings/items/shizuku_installer/shizuku_installer.dart';
 import 'package:glass_down_v2/ui/widgets/settings/common/group_header.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
@@ -63,6 +64,8 @@ Future<T?> showQuickSettingsSheet<T>() {
                             GroupHeader(name: 'Apps'),
                             DeleteOldVersions(rounded: true),
                             OfferDeletingOldApks(rounded: true),
+                            GroupHeader(name: 'Others'),
+                            ShizukuInstaller(rounded: true),
                           ],
                         ),
                       ),

--- a/lib/ui/bottom_sheets/updater/update_sheet.dart
+++ b/lib/ui/bottom_sheets/updater/update_sheet.dart
@@ -114,14 +114,6 @@ Future<T?> showUpdaterSheet<T>() {
                     ),
                   ],
                   verticalSpaceSmall,
-                  if (!viewModel.installStatus) ...[
-                    const ListTile(
-                      title: Text(
-                        'App has not been granted permission to install packages. Grant it via "Show permissions page" option in Settings to enable auto updating.',
-                      ),
-                    ),
-                    verticalSpaceSmall,
-                  ],
                   Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
@@ -134,7 +126,7 @@ Future<T?> showUpdaterSheet<T>() {
                       ),
                       horizontalSpaceMedium,
                       FilledButton(
-                        onPressed: viewModel.started || !viewModel.installStatus
+                        onPressed: viewModel.started
                             ? null
                             : () => viewModel.downloadUpdate(),
                         child: const Text('Update'),

--- a/lib/ui/bottom_sheets/updater/update_sheet.dart
+++ b/lib/ui/bottom_sheets/updater/update_sheet.dart
@@ -91,8 +91,16 @@ Future<T?> showUpdaterSheet<T>() {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           ListTile(
+                            tileColor: Theme.of(context)
+                                .colorScheme
+                                .surfaceTint
+                                .withAlpha(20),
                             title: LinearProgressIndicator(
                               value: viewModel.progress.toInt() / 100,
+                              backgroundColor: Theme.of(context)
+                                  .colorScheme
+                                  .surfaceTint
+                                  .withAlpha(20),
                             ),
                             trailing: Text(
                               '${viewModel.progress.toStringAsFixed((0))}%',

--- a/lib/ui/bottom_sheets/updater/update_sheet.dart
+++ b/lib/ui/bottom_sheets/updater/update_sheet.dart
@@ -14,7 +14,10 @@ Future<T?> showUpdaterSheet<T>() {
     builder: (context) {
       return ViewModelBuilder.reactive(
         viewModelBuilder: () => UpdateSheetModel(),
-        onViewModelReady: (viewModel) => viewModel.checkUpdates(),
+        onViewModelReady: (viewModel) {
+          viewModel.checkUpdates();
+          viewModel.canInstallPackages();
+        },
         builder: (context, viewModel, child) {
           return Container(
             padding: const EdgeInsets.fromLTRB(20, 20, 20, 30),
@@ -111,6 +114,14 @@ Future<T?> showUpdaterSheet<T>() {
                     ),
                   ],
                   verticalSpaceSmall,
+                  if (!viewModel.installStatus) ...[
+                    const ListTile(
+                      title: Text(
+                        'App has not been granted permission to install packages. Grant it via "Show permissions page" option in Settings to enable auto updating.',
+                      ),
+                    ),
+                    verticalSpaceSmall,
+                  ],
                   Row(
                     mainAxisAlignment: MainAxisAlignment.end,
                     children: [
@@ -123,7 +134,7 @@ Future<T?> showUpdaterSheet<T>() {
                       ),
                       horizontalSpaceMedium,
                       FilledButton(
-                        onPressed: viewModel.started
+                        onPressed: viewModel.started || !viewModel.installStatus
                             ? null
                             : () => viewModel.downloadUpdate(),
                         child: const Text('Update'),

--- a/lib/ui/bottom_sheets/updater/update_sheet_model.dart
+++ b/lib/ui/bottom_sheets/updater/update_sheet_model.dart
@@ -60,12 +60,28 @@ class UpdateSheetModel extends ReactiveViewModel {
   }
 
   Future<void> downloadUpdate() async {
-    final version = pickedVersion == PickedVersion.arm64
-        ? updateInfo!.arm64
-        : updateInfo!.arm32;
-    _started = true;
-    notifyListeners();
-    await _updater.downloadUpdate(version, token);
+    try {
+      final version = pickedVersion == PickedVersion.arm64
+          ? updateInfo!.arm64
+          : updateInfo!.arm32;
+      _started = true;
+      notifyListeners();
+      final result = await _updater.downloadUpdate(version, token);
+      if (result != null) {
+        if (!result) {
+          _snackbar.showCustomSnackBar(
+            message: 'Update package downloaded to $defaultDirPath',
+            variant: SnackbarType.info,
+          );
+        }
+      }
+    } catch (e) {
+      FlutterLogs.logError(
+        runtimeType.toString(),
+        getFunctionName(),
+        e is UpdateError ? e.message : e.toString(),
+      );
+    }
   }
 
   Future<void> checkUpdates() async {

--- a/lib/ui/bottom_sheets/updater/update_sheet_model.dart
+++ b/lib/ui/bottom_sheets/updater/update_sheet_model.dart
@@ -4,6 +4,7 @@ import 'package:glass_down_v2/app/app.locator.dart';
 import 'package:glass_down_v2/app/app.snackbar.dart';
 import 'package:glass_down_v2/models/errors/update_error.dart';
 import 'package:glass_down_v2/models/update_info.dart';
+import 'package:glass_down_v2/services/settings_service.dart';
 import 'package:glass_down_v2/services/updater_service.dart';
 import 'package:glass_down_v2/util/function_name.dart';
 import 'package:stacked/stacked.dart';
@@ -14,8 +15,24 @@ enum PickedVersion { arm64, arm32 }
 class UpdateSheetModel extends ReactiveViewModel {
   final _updater = locator<UpdaterService>();
   final _snackbar = locator<SnackbarService>();
+  final _settings = locator<SettingsService>();
 
   final token = CancelToken();
+
+  bool _installStatus = false;
+  bool get installStatus => _installStatus;
+
+  Future<void> canInstallPackages() async {
+    try {
+      _installStatus = await _settings.installGranted();
+      rebuildUi();
+    } catch (e) {
+      _snackbar.showCustomSnackBar(
+        message: "Cannot check install packages permission",
+        variant: SnackbarType.info,
+      );
+    }
+  }
 
   double get progress => _updater.downloadProgress;
 

--- a/lib/ui/theme/theme_builder.dart
+++ b/lib/ui/theme/theme_builder.dart
@@ -43,7 +43,9 @@ class ThemeBuilder extends StackedView<ThemeBuilderModel> {
                 ? 'CustomFont'
                 : GoogleFonts.interTight().fontFamily,
           ),
-          initialRoute: Routes.appsView,
+          initialRoute: viewModel.shownPermissions
+              ? Routes.appsView
+              : Routes.permissionsView,
           onGenerateRoute: StackedRouter().onGenerateRoute,
           navigatorKey: StackedService.navigatorKey,
           navigatorObservers: [

--- a/lib/ui/theme/theme_builder_model.dart
+++ b/lib/ui/theme/theme_builder_model.dart
@@ -14,6 +14,7 @@ class ThemeBuilderModel extends ReactiveViewModel {
   bool get monetEnabled => _settings.monetEnabled;
   MainColor get customTheme => _settings.customColor;
   bool get useImportedFont => _settings.useImportedFont;
+  bool get shownPermissions => _settings.shownPermissions;
 
   ThemeScheme getTheme(MainColor color) {
     return _themes.getTheme(color);

--- a/lib/ui/views/apps/apps_view.dart
+++ b/lib/ui/views/apps/apps_view.dart
@@ -112,7 +112,6 @@ class AppsView extends StackedView<AppsViewModel> {
   @override
   void onViewModelReady(AppsViewModel viewModel) {
     super.onViewModelReady(viewModel);
-    viewModel.checkPermissions();
     viewModel.allApps();
     viewModel.getLatestPatches();
     viewModel.checkUpdates();

--- a/lib/ui/views/apps/apps_viewmodel.dart
+++ b/lib/ui/views/apps/apps_viewmodel.dart
@@ -13,7 +13,6 @@ import 'package:glass_down_v2/ui/bottom_sheets/updater/update_sheet.dart';
 import 'package:glass_down_v2/ui/transition/custom_transitions.dart';
 import 'package:glass_down_v2/ui/views/permissions/permissions_view.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
-import 'package:permission_handler/permission_handler.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
 
@@ -51,16 +50,7 @@ class AppsViewModel extends StreamViewModel {
   Stream<InternetStatus> get stream => InternetConnection().onStatusChange;
 
   Future<void> checkPermissions() async {
-    final sdk = await _settings.getSdkVersion();
-    bool storageGranted = false;
-    if (sdk >= 30) {
-      storageGranted = await Permission.manageExternalStorage.status.isGranted;
-    } else {
-      storageGranted = await Permission.storage.status.isGranted;
-    }
-    final installGranted =
-        await Permission.requestInstallPackages.status.isGranted;
-    if (!storageGranted || !installGranted) {
+    if (!_settings.shownPermissions) {
       _nav.replaceWithTransition(const PermissionsView());
     }
   }

--- a/lib/ui/views/apps/apps_viewmodel.dart
+++ b/lib/ui/views/apps/apps_viewmodel.dart
@@ -11,7 +11,6 @@ import 'package:glass_down_v2/services/updater_service.dart';
 import 'package:glass_down_v2/ui/bottom_sheets/add_app/add_app.dart';
 import 'package:glass_down_v2/ui/bottom_sheets/updater/update_sheet.dart';
 import 'package:glass_down_v2/ui/transition/custom_transitions.dart';
-import 'package:glass_down_v2/ui/views/permissions/permissions_view.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
@@ -48,12 +47,6 @@ class AppsViewModel extends StreamViewModel {
 
   @override
   Stream<InternetStatus> get stream => InternetConnection().onStatusChange;
-
-  Future<void> checkPermissions() async {
-    if (!_settings.shownPermissions) {
-      _nav.replaceWithTransition(const PermissionsView());
-    }
-  }
 
   Future<void> showSettings() async {
     await _nav.navigateTo(

--- a/lib/ui/views/download_status/download_status_view.dart
+++ b/lib/ui/views/download_status/download_status_view.dart
@@ -78,22 +78,22 @@ class DownloadStatusView extends StackedView<DownloadStatusViewModel> {
                     child: Column(
                       children: [
                         StatusCard(
-                          title: 'Scrapping download page',
+                          title: 'Scrape download page',
                           complete: viewModel.pageStatus.$1,
                           // subTitle: viewModel.pageStatus.$2,
                         ),
                         StatusCard(
-                          title: 'Scrapping download link',
+                          title: 'Scrape download link',
                           complete: viewModel.linkStatus.$1,
                           // subTitle: viewModel.linkStatus.$2,
                         ),
                         StatusCard(
-                          title: 'Getting save path',
+                          title: 'Get save path',
                           complete: viewModel.saveStatus.$1,
                           // subTitle: viewModel.saveStatus.$2,
                         ),
                         ProgressCard(
-                          title: 'Downloading & saving APK',
+                          title: 'Download APK',
                           complete: viewModel.apkStatus.$1 ?? true,
                           progress: viewModel.downloadProgress,
                         ),
@@ -107,9 +107,10 @@ class DownloadStatusView extends StackedView<DownloadStatusViewModel> {
                         child: Padding(
                           padding: const EdgeInsets.fromLTRB(16, 16, 4, 0),
                           child: FilledButton.icon(
-                            onPressed: viewModel.success
-                                ? () => viewModel.openApk()
-                                : null,
+                            onPressed:
+                                viewModel.success && viewModel.installStatus
+                                    ? () => viewModel.openApk()
+                                    : null,
                             icon: const Icon(Icons.install_mobile),
                             label: const Text('Install APK'),
                           ),

--- a/lib/ui/views/download_status/download_status_view.dart
+++ b/lib/ui/views/download_status/download_status_view.dart
@@ -107,10 +107,9 @@ class DownloadStatusView extends StackedView<DownloadStatusViewModel> {
                         child: Padding(
                           padding: const EdgeInsets.fromLTRB(16, 16, 4, 0),
                           child: FilledButton.icon(
-                            onPressed:
-                                viewModel.success && viewModel.installStatus
-                                    ? () => viewModel.openApk()
-                                    : null,
+                            onPressed: viewModel.success
+                                ? () => viewModel.openApk()
+                                : null,
                             icon: const Icon(Icons.install_mobile),
                             label: const Text('Install APK'),
                           ),

--- a/lib/ui/views/download_status/download_status_view.dart
+++ b/lib/ui/views/download_status/download_status_view.dart
@@ -103,26 +103,39 @@ class DownloadStatusView extends StackedView<DownloadStatusViewModel> {
                   Row(
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
-                      Expanded(
-                        child: Padding(
-                          padding: const EdgeInsets.fromLTRB(16, 16, 4, 0),
-                          child: FilledButton.icon(
-                            onPressed: viewModel.success
-                                ? () => viewModel.openApk()
-                                : null,
-                            icon: const Icon(Icons.install_mobile),
-                            label: const Text('Install APK'),
+                      if (viewModel.installing)
+                        Expanded(
+                          child: Padding(
+                            padding: const EdgeInsets.fromLTRB(16, 16, 4, 0),
+                            child: FilledButton.icon(
+                              onPressed: null,
+                              icon: const Icon(Icons.downloading),
+                              label: const Text('Installing...'),
+                            ),
+                          ),
+                        )
+                      else
+                        Expanded(
+                          child: Padding(
+                            padding: const EdgeInsets.fromLTRB(16, 16, 4, 0),
+                            child: FilledButton.icon(
+                              onPressed: viewModel.success
+                                  ? () => viewModel.openApk()
+                                  : null,
+                              icon: const Icon(Icons.install_mobile),
+                              label: const Text('Install APK'),
+                            ),
                           ),
                         ),
-                      ),
                       Expanded(
                         child: Padding(
                           padding: const EdgeInsets.fromLTRB(4, 16, 16, 0),
                           child: FilledButton.icon(
-                            onPressed:
-                                viewModel.revancedExists && viewModel.success
-                                    ? () => viewModel.openRevanced()
-                                    : null,
+                            onPressed: viewModel.revancedExists &&
+                                    viewModel.success &&
+                                    !viewModel.installing
+                                ? () => viewModel.openRevanced()
+                                : null,
                             icon: SvgPicture.asset(
                               Theme.of(context).brightness == Brightness.light
                                   ? viewModel.revancedExists &&
@@ -148,10 +161,12 @@ class DownloadStatusView extends StackedView<DownloadStatusViewModel> {
                         child: Padding(
                           padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
                           child: FilledButton.tonalIcon(
-                            onPressed: () {
-                              viewModel.cancel();
-                              viewModel.returnTo(home: true);
-                            },
+                            onPressed: !viewModel.installing
+                                ? () {
+                                    viewModel.cancel();
+                                    viewModel.returnTo(home: true);
+                                  }
+                                : null,
                             icon: const Icon(
                               Icons.keyboard_double_arrow_left_rounded,
                             ),

--- a/lib/ui/views/download_status/download_status_viewmodel.dart
+++ b/lib/ui/views/download_status/download_status_viewmodel.dart
@@ -6,6 +6,7 @@ import 'package:glass_down_v2/app/app.locator.dart';
 import 'package:glass_down_v2/app/app.snackbar.dart';
 import 'package:glass_down_v2/models/app_info.dart';
 import 'package:glass_down_v2/services/scraper_service.dart';
+import 'package:glass_down_v2/services/settings_service.dart';
 import 'package:glass_down_v2/ui/views/apps/apps_view.dart';
 import 'package:open_filex/open_filex.dart';
 import 'package:stacked/stacked.dart';
@@ -17,6 +18,7 @@ class DownloadStatusViewModel extends ReactiveViewModel {
   final _token = CancelToken();
   final _snackbar = locator<SnackbarService>();
   final _dialog = locator<DialogService>();
+  final _settings = locator<SettingsService>();
 
   CancelableOperation<bool>? operation;
 
@@ -43,6 +45,21 @@ class DownloadStatusViewModel extends ReactiveViewModel {
 
   bool _saiExists = false;
   bool get saiExists => _saiExists;
+
+  bool _installStatus = false;
+  bool get installStatus => _installStatus;
+
+  Future<void> canInstallPackages() async {
+    try {
+      _installStatus = await _settings.installGranted();
+      rebuildUi();
+    } catch (e) {
+      _snackbar.showCustomSnackBar(
+        message: "Cannot check install packages permission",
+        variant: SnackbarType.info,
+      );
+    }
+  }
 
   Future<void> cancel() async {
     try {

--- a/lib/ui/views/download_status/download_status_viewmodel.dart
+++ b/lib/ui/views/download_status/download_status_viewmodel.dart
@@ -34,6 +34,9 @@ class DownloadStatusViewModel extends ReactiveViewModel {
     return _canPop;
   }
 
+  bool _installing = false;
+  bool get installing => _installing;
+
   Status get pageStatus => _scraper.pageStatus;
   Status get linkStatus => _scraper.linkStatus;
   Status get apkStatus => _scraper.apkStatus;
@@ -104,10 +107,15 @@ class DownloadStatusViewModel extends ReactiveViewModel {
       final isBundle = saveStatus.$2!.split('.').last == 'apkm';
       if (isBundle) {
         if (shizukuAvailable) {
-          await ShizukuApkInstaller.installAPK(
-            saveStatus.$3.toString(),
-            'com.sinneida.glassdown2',
-          );
+          _installing = true;
+          rebuildUi();
+          // await ShizukuApkInstaller.installAPK(
+          //   saveStatus.$3.toString(),
+          //   'com.sinneida.glassdown2',
+          // );
+          await Future.delayed(const Duration(seconds: 4));
+          _installing = false;
+          rebuildUi();
           return;
         }
         if (_saiExists) {
@@ -119,16 +127,23 @@ class DownloadStatusViewModel extends ReactiveViewModel {
         }
       } else {
         if (shizukuAvailable) {
+          _installing = true;
+          rebuildUi();
           await ShizukuApkInstaller.installAPK(
             saveStatus.$3.toString(),
             'com.sinneida.glassdown2',
           );
+          _installing = false;
+          rebuildUi();
           return;
         }
         OpenFilex.open(saveStatus.$2);
       }
     } catch (e) {
       showSnackbar('Cannot open downloaded APK');
+      _installing = false;
+    } finally {
+      rebuildUi();
     }
   }
 

--- a/lib/ui/views/permissions/permissions_view.dart
+++ b/lib/ui/views/permissions/permissions_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:glass_down_v2/ui/common/ui_helpers.dart';
 import 'package:stacked/stacked.dart';
 
 import 'permissions_viewmodel.dart';
@@ -54,6 +55,7 @@ class PermissionsView extends StackedView<PermissionsViewModel> {
                               ),
                       ),
                     ),
+                    verticalSpaceTiny,
                     Card(
                       clipBehavior: Clip.antiAlias,
                       elevation: 1,
@@ -82,6 +84,7 @@ class PermissionsView extends StackedView<PermissionsViewModel> {
                               ),
                       ),
                     ),
+                    verticalSpaceSmall,
                     Row(
                       children: [
                         Expanded(

--- a/lib/ui/views/permissions/permissions_view.dart
+++ b/lib/ui/views/permissions/permissions_view.dart
@@ -84,6 +84,35 @@ class PermissionsView extends StackedView<PermissionsViewModel> {
                               ),
                       ),
                     ),
+                    verticalSpaceTiny,
+                    Card(
+                      clipBehavior: Clip.antiAlias,
+                      elevation: 1,
+                      child: ListTile(
+                        onTap: () => viewModel.requestShizukuPermission(),
+                        title: const Text('Shizuku installer'),
+                        subtitle: const Text(
+                          'Needed for installing APKs without user interaction',
+                        ),
+                        tileColor: !viewModel.shizuku
+                            ? Theme.of(context)
+                                .colorScheme
+                                .surfaceTint
+                                .withAlpha(20)
+                            : Colors.lightGreenAccent.withAlpha(40),
+                        trailing: !viewModel.shizuku
+                            ? const Icon(
+                                Icons.close,
+                                color: Colors.redAccent,
+                                size: 30,
+                              )
+                            : const Icon(
+                                Icons.check,
+                                color: Colors.green,
+                                size: 30,
+                              ),
+                      ),
+                    ),
                     verticalSpaceSmall,
                     Row(
                       children: [

--- a/lib/ui/views/permissions/permissions_view.dart
+++ b/lib/ui/views/permissions/permissions_view.dart
@@ -33,7 +33,7 @@ class PermissionsView extends StackedView<PermissionsViewModel> {
                         onTap: () => viewModel.requestStoragePermission(),
                         title: const Text('Storage'),
                         subtitle: const Text(
-                          'Needed for importing/exporting app list, deleting already downloaded APKs etc.',
+                          'Needed if you want a different file system localisation for importing/exporting app list, deleting already downloaded APKs etc. than default one (Downloads/GlassDown)',
                         ),
                         tileColor: !viewModel.storage
                             ? Theme.of(context)
@@ -67,7 +67,7 @@ class PermissionsView extends StackedView<PermissionsViewModel> {
                             ? Theme.of(context)
                                 .colorScheme
                                 .surfaceTint
-                                .withAlpha(40)
+                                .withAlpha(20)
                             : Colors.lightGreenAccent.withAlpha(40),
                         trailing: !viewModel.install
                             ? const Icon(
@@ -82,17 +82,17 @@ class PermissionsView extends StackedView<PermissionsViewModel> {
                               ),
                       ),
                     ),
-                    if (viewModel.install && viewModel.storage)
-                      Row(
-                        children: [
-                          Expanded(
-                            child: FilledButton(
-                              onPressed: () => viewModel.goHome(),
-                              child: const Text('Finish'),
-                            ),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: FilledButton(
+                            onPressed: () => viewModel.goHome(),
+                            child: const Text('Finish'),
                           ),
-                        ],
-                      )
+                        ),
+                      ],
+                    )
+                    // if (viewModel.storage)
                   ],
                 ),
               ),

--- a/lib/ui/views/permissions/permissions_view.dart
+++ b/lib/ui/views/permissions/permissions_view.dart
@@ -114,7 +114,6 @@ class PermissionsView extends StackedView<PermissionsViewModel> {
 
   @override
   void onViewModelReady(PermissionsViewModel viewModel) {
-    super.onViewModelReady(viewModel);
     viewModel.init();
   }
 }

--- a/lib/ui/views/permissions/permissions_viewmodel.dart
+++ b/lib/ui/views/permissions/permissions_viewmodel.dart
@@ -4,6 +4,7 @@ import 'package:glass_down_v2/services/settings_service.dart';
 import 'package:glass_down_v2/ui/views/apps/apps_view.dart';
 import 'package:glass_down_v2/util/function_name.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:shizuku_apk_installer/shizuku_apk_installer.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
 
@@ -19,6 +20,9 @@ class PermissionsViewModel extends BaseViewModel {
 
   bool _install = false;
   bool get install => _install;
+
+  bool _shizuku = false;
+  bool get shizuku => _shizuku;
 
   Future<void> init() async {
     final sdk = await _settings.getSdkVersion();
@@ -68,6 +72,12 @@ class PermissionsViewModel extends BaseViewModel {
   Future<void> requestInstallPermission() async {
     final result = await Permission.requestInstallPackages.request();
     _install = result.isGranted;
+    rebuildUi();
+  }
+
+  Future<void> requestShizukuPermission() async {
+    final result = await ShizukuApkInstaller.checkPermission();
+    _shizuku = result?.contains('granted') ?? false;
     rebuildUi();
   }
 }

--- a/lib/ui/views/permissions/permissions_viewmodel.dart
+++ b/lib/ui/views/permissions/permissions_viewmodel.dart
@@ -34,6 +34,8 @@ class PermissionsViewModel extends BaseViewModel {
     }
     final installGranted =
         await Permission.requestInstallPackages.status.isGranted;
+    final result = await ShizukuApkInstaller.checkPermission();
+    _shizuku = result?.contains('granted') ?? false;
     _storage = storageGranted;
     _install = installGranted;
     rebuildUi();

--- a/lib/ui/views/permissions/permissions_viewmodel.dart
+++ b/lib/ui/views/permissions/permissions_viewmodel.dart
@@ -12,7 +12,7 @@ class PermissionsViewModel extends BaseViewModel {
   final _settings = locator<SettingsService>();
 
   final description =
-      'Following permissions are required for the app to run. Click on the tile to enable them.';
+      'Following permissions are optional. Click on the tile to enable them.';
 
   bool _storage = false;
   bool get storage => _storage;

--- a/lib/ui/views/permissions/permissions_viewmodel.dart
+++ b/lib/ui/views/permissions/permissions_viewmodel.dart
@@ -37,6 +37,7 @@ class PermissionsViewModel extends BaseViewModel {
 
   Future<void> goHome() async {
     await createAppDir();
+    _settings.setShownPermissions(true);
     _nav.clearStackAndShowView(const AppsView());
   }
 

--- a/lib/ui/views/settings/items/apk_save_path/apk_save_path.dart
+++ b/lib/ui/views/settings/items/apk_save_path/apk_save_path.dart
@@ -14,10 +14,12 @@ class ApkSavePath extends StackedView<ApkSavePathModel> {
     Widget? child,
   ) {
     return InkWell(
-      onTap: () => viewModel.pickFolder(context),
+      onTap:
+          viewModel.storageStatus ? () => viewModel.pickFolder(context) : null,
       child: ItemWrapper(
         mainText: 'Change APK save path',
         secondaryText: 'Saved in: ${viewModel.exportApkPath}',
+        enabled: viewModel.storageStatus,
       ),
     );
   }
@@ -27,4 +29,10 @@ class ApkSavePath extends StackedView<ApkSavePathModel> {
     BuildContext context,
   ) =>
       ApkSavePathModel();
+
+  @override
+  void onViewModelReady(ApkSavePathModel viewModel) {
+    super.onViewModelReady(viewModel);
+    viewModel.getStoragePermissionStatus();
+  }
 }

--- a/lib/ui/views/settings/items/apk_save_path/apk_save_path_model.dart
+++ b/lib/ui/views/settings/items/apk_save_path/apk_save_path_model.dart
@@ -15,6 +15,21 @@ class ApkSavePathModel extends BaseViewModel {
   final _snackbar = locator<SnackbarService>();
   final _settings = locator<SettingsService>();
 
+  bool _storageStatus = false;
+  bool get storageStatus => _storageStatus;
+
+  Future<void> getStoragePermissionStatus() async {
+    try {
+      _storageStatus = await _settings.storageGranted();
+      rebuildUi();
+    } catch (e) {
+      _snackbar.showCustomSnackBar(
+        message: e is IOError ? e.message : "Can't pick this folder",
+        variant: SnackbarType.info,
+      );
+    }
+  }
+
   String get exportApkPath {
     if (_settings.apkSavePath.length <= 20) {
       return 'Main Storage';

--- a/lib/ui/views/settings/items/export_apps/export_apps.dart
+++ b/lib/ui/views/settings/items/export_apps/export_apps.dart
@@ -19,7 +19,9 @@ class ExportApps extends StackedView<ExportAppsModel> {
         mainText: 'Export apps',
         secondaryText: 'Saved in: ${viewModel.exportAppsPath}',
         trailingWidget: FilledButton.tonal(
-          onPressed: () => viewModel.pickFolder(context),
+          onPressed: viewModel.storageStatus
+              ? () => viewModel.pickFolder(context)
+              : null,
           child: const Text('Change path'),
         ),
       ),

--- a/lib/ui/views/settings/items/export_apps/export_apps.dart
+++ b/lib/ui/views/settings/items/export_apps/export_apps.dart
@@ -33,4 +33,10 @@ class ExportApps extends StackedView<ExportAppsModel> {
     BuildContext context,
   ) =>
       ExportAppsModel();
+
+  @override
+  void onViewModelReady(ExportAppsModel viewModel) {
+    super.onViewModelReady(viewModel);
+    viewModel.getStoragePermissionStatus();
+  }
 }

--- a/lib/ui/views/settings/items/export_apps/export_apps_model.dart
+++ b/lib/ui/views/settings/items/export_apps/export_apps_model.dart
@@ -17,6 +17,21 @@ class ExportAppsModel extends ReactiveViewModel {
   final _snackbar = locator<SnackbarService>();
   final _settings = locator<SettingsService>();
 
+  bool _storageStatus = false;
+  bool get storageStatus => _storageStatus;
+
+  Future<void> getStoragePermissionStatus() async {
+    try {
+      _storageStatus = await _settings.storageGranted();
+      rebuildUi();
+    } catch (e) {
+      _snackbar.showCustomSnackBar(
+        message: e is IOError ? e.message : "Can't pick this folder",
+        variant: SnackbarType.info,
+      );
+    }
+  }
+
   String get exportAppsPath {
     if (_settings.exportAppsPath.length <= 20) {
       return 'Main Storage';

--- a/lib/ui/views/settings/items/export_logs/export_logs.dart
+++ b/lib/ui/views/settings/items/export_logs/export_logs.dart
@@ -33,4 +33,10 @@ class ExportLogs extends StackedView<ExportLogsModel> {
     BuildContext context,
   ) =>
       ExportLogsModel();
+
+  @override
+  void onViewModelReady(ExportLogsModel viewModel) {
+    super.onViewModelReady(viewModel);
+    viewModel.getStoragePermissionStatus();
+  }
 }

--- a/lib/ui/views/settings/items/export_logs/export_logs.dart
+++ b/lib/ui/views/settings/items/export_logs/export_logs.dart
@@ -19,7 +19,9 @@ class ExportLogs extends StackedView<ExportLogsModel> {
         mainText: 'Export logs',
         secondaryText: 'Saved in: ${viewModel.exportLogsPath}',
         trailingWidget: FilledButton.tonal(
-          onPressed: () => viewModel.pickFolder(context),
+          onPressed: viewModel.storageStatus
+              ? () => viewModel.pickFolder(context)
+              : null,
           child: const Text('Change path'),
         ),
       ),

--- a/lib/ui/views/settings/items/export_logs/export_logs_model.dart
+++ b/lib/ui/views/settings/items/export_logs/export_logs_model.dart
@@ -17,6 +17,21 @@ class ExportLogsModel extends ReactiveViewModel {
   final _snackbar = locator<SnackbarService>();
   final _settings = locator<SettingsService>();
 
+  bool _storageStatus = false;
+  bool get storageStatus => _storageStatus;
+
+  Future<void> getStoragePermissionStatus() async {
+    try {
+      _storageStatus = await _settings.storageGranted();
+      rebuildUi();
+    } catch (e) {
+      _snackbar.showCustomSnackBar(
+        message: e is IOError ? e.message : "Can't pick this folder",
+        variant: SnackbarType.info,
+      );
+    }
+  }
+
   String get exportLogsPath {
     if (_settings.exportLogsPath.length <= 20) {
       return 'Main Storage';

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -14,15 +14,14 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
     Widget? child,
   ) {
     return InkWell(
-      onTap: viewModel.shizukuAvailable
+      onTap: viewModel.shizukuAvailable()
           ? () => viewModel.updateValue(!viewModel.shizukuEnabled)
           : null,
       child: ItemWrapper(
         mainText: 'Shizuku installer (BETA)',
-        secondaryText: viewModel.getStatus(),
-        threeLined: true,
+        secondaryText: 'Install APKs without interaction',
         trailingWidget: Switch(
-          onChanged: viewModel.shizukuAvailable
+          onChanged: viewModel.shizukuAvailable()
               ? (value) => viewModel.updateValue(value)
               : null,
           value: viewModel.shizukuEnabled,

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:glass_down_v2/ui/widgets/settings/common/item_wrapper.dart';
+import 'package:stacked/stacked.dart';
+
+import 'shizuku_installer_model.dart';
+
+class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
+  const ShizukuInstaller({super.key});
+
+  @override
+  Widget builder(
+    BuildContext context,
+    ShizukuInstallerModel viewModel,
+    Widget? child,
+  ) {
+    return InkWell(
+      onTap: () => viewModel.updateValue(!viewModel.shizukuEnabled),
+      child: ItemWrapper(
+        mainText: 'Shizuku installer',
+        secondaryText: 'Install updates automatically\nStatus: <status>',
+        threeLined: true,
+        enabled: false,
+        trailingWidget: Switch(
+          // onChanged: (value) => viewModel.updateValue(value),
+          onChanged: null,
+          value: viewModel.shizukuEnabled,
+        ),
+      ),
+    );
+  }
+
+  @override
+  ShizukuInstallerModel viewModelBuilder(
+    BuildContext context,
+  ) =>
+      ShizukuInstallerModel();
+}

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -24,7 +24,7 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
           ? () => viewModel.updateValue(!viewModel.shizukuEnabled)
           : null,
       child: ItemWrapper(
-        mainText: 'Shizuku installer (BETA)',
+        mainText: 'Shizuku installer',
         secondaryText: 'Install APKs without interaction',
         trailingWidget: Switch(
           onChanged: viewModel.shizukuAvailable()

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -17,7 +17,7 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
       onTap: () => viewModel.updateValue(!viewModel.shizukuEnabled),
       child: ItemWrapper(
         mainText: 'Shizuku installer',
-        secondaryText: 'Install APKs without interaction\nStatus: <status>',
+        secondaryText: viewModel.getStatus(),
         threeLined: true,
         enabled: false,
         trailingWidget: Switch(
@@ -34,4 +34,10 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
     BuildContext context,
   ) =>
       ShizukuInstallerModel();
+
+  @override
+  void onViewModelReady(ShizukuInstallerModel viewModel) {
+    super.onViewModelReady(viewModel);
+    viewModel.checkShizukuStatus();
+  }
 }

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -19,10 +19,8 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
         mainText: 'Shizuku installer',
         secondaryText: viewModel.getStatus(),
         threeLined: true,
-        enabled: false,
         trailingWidget: Switch(
-          // onChanged: (value) => viewModel.updateValue(value),
-          onChanged: null,
+          onChanged: (value) => viewModel.updateValue(value),
           value: viewModel.shizukuEnabled,
         ),
       ),

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -5,7 +5,12 @@ import 'package:stacked/stacked.dart';
 import 'shizuku_installer_model.dart';
 
 class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
-  const ShizukuInstaller({super.key});
+  const ShizukuInstaller({
+    super.key,
+    this.rounded = false,
+  });
+
+  final bool rounded;
 
   @override
   Widget builder(
@@ -14,6 +19,7 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
     Widget? child,
   ) {
     return InkWell(
+      borderRadius: rounded ? BorderRadius.circular(16) : null,
       onTap: viewModel.shizukuAvailable()
           ? () => viewModel.updateValue(!viewModel.shizukuEnabled)
           : null,

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -17,7 +17,7 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
       onTap: () => viewModel.updateValue(!viewModel.shizukuEnabled),
       child: ItemWrapper(
         mainText: 'Shizuku installer',
-        secondaryText: 'Install updates automatically\nStatus: <status>',
+        secondaryText: 'Install APKs without interaction\nStatus: <status>',
         threeLined: true,
         enabled: false,
         trailingWidget: Switch(

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -14,13 +14,17 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
     Widget? child,
   ) {
     return InkWell(
-      onTap: () => viewModel.updateValue(!viewModel.shizukuEnabled),
+      onTap: viewModel.shizukuAvailable
+          ? () => viewModel.updateValue(!viewModel.shizukuEnabled)
+          : null,
       child: ItemWrapper(
         mainText: 'Shizuku installer',
         secondaryText: viewModel.getStatus(),
         threeLined: true,
         trailingWidget: Switch(
-          onChanged: (value) => viewModel.updateValue(value),
+          onChanged: viewModel.shizukuAvailable
+              ? (value) => viewModel.updateValue(value)
+              : null,
           value: viewModel.shizukuEnabled,
         ),
       ),
@@ -32,10 +36,4 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
     BuildContext context,
   ) =>
       ShizukuInstallerModel();
-
-  @override
-  void onViewModelReady(ShizukuInstallerModel viewModel) {
-    super.onViewModelReady(viewModel);
-    viewModel.checkShizukuStatus();
-  }
 }

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer.dart
@@ -18,7 +18,7 @@ class ShizukuInstaller extends StackedView<ShizukuInstallerModel> {
           ? () => viewModel.updateValue(!viewModel.shizukuEnabled)
           : null,
       child: ItemWrapper(
-        mainText: 'Shizuku installer',
+        mainText: 'Shizuku installer (BETA)',
         secondaryText: viewModel.getStatus(),
         threeLined: true,
         trailingWidget: Switch(

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
@@ -11,6 +11,17 @@ class ShizukuInstallerModel extends BaseViewModel {
   String? _status;
   String? get status => _status;
 
+  bool get shizukuAvailable {
+    if (_status != null) {
+      if (!_status!.contains('binder_not_found')) {
+        return true;
+      }
+    } else {
+      return true;
+    }
+    return false;
+  }
+
   Future<void> checkShizukuStatus() async {
     _status = await ShizukuApkInstaller.checkPermission();
     rebuildUi();
@@ -42,8 +53,21 @@ class ShizukuInstallerModel extends BaseViewModel {
     return '$description\n$status\n$message';
   }
 
-  void updateValue(bool value) {
-    _settings.setShizuku(value);
+  Future<void> updateValue(bool value) async {
+    _status = await ShizukuApkInstaller.checkPermission();
+    print(status);
+    if (_status != null) {
+      if (_status!.contains('granted')) {
+        _settings.setShizuku(value);
+        rebuildUi();
+        return;
+      } else {
+        _settings.setShizuku(false);
+        rebuildUi();
+        return;
+      }
+    }
+    _settings.setShizuku(false);
     rebuildUi();
   }
 }

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
@@ -1,11 +1,26 @@
 import 'package:glass_down_v2/app/app.locator.dart';
 import 'package:glass_down_v2/services/settings_service.dart';
 import 'package:stacked/stacked.dart';
+import 'package:shizuku_apk_installer/shizuku_apk_installer.dart';
 
 class ShizukuInstallerModel extends BaseViewModel {
   bool get shizukuEnabled => _settings.shizuku;
 
   final _settings = locator<SettingsService>();
+
+  String? _status;
+  String? get status => _status;
+
+  Future<void> checkShizukuStatus() async {
+    _status = await ShizukuApkInstaller.checkPermission();
+    rebuildUi();
+  }
+
+  String getStatus() {
+    const description = 'Install APKs without interaction';
+    final status = 'Status: $_status';
+    return '$description\n$status';
+  }
 
   void updateValue(bool value) {
     _settings.setShizuku(value);

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
@@ -1,7 +1,6 @@
 import 'package:glass_down_v2/app/app.locator.dart';
 import 'package:glass_down_v2/services/settings_service.dart';
 import 'package:stacked/stacked.dart';
-import 'package:shizuku_apk_installer/shizuku_apk_installer.dart';
 
 class ShizukuInstallerModel extends BaseViewModel {
   bool get shizukuEnabled => _settings.shizuku;
@@ -12,7 +11,7 @@ class ShizukuInstallerModel extends BaseViewModel {
   String? get status => _status;
 
   Future<void> checkShizukuStatus() async {
-    _status = await ShizukuApkInstaller.checkPermission();
+    _status = await _settings.checkShizukuStatus();
     rebuildUi();
   }
 

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
@@ -1,0 +1,14 @@
+import 'package:glass_down_v2/app/app.locator.dart';
+import 'package:glass_down_v2/services/settings_service.dart';
+import 'package:stacked/stacked.dart';
+
+class ShizukuInstallerModel extends BaseViewModel {
+  bool get shizukuEnabled => _settings.shizuku;
+
+  final _settings = locator<SettingsService>();
+
+  void updateValue(bool value) {
+    _settings.setShizuku(value);
+    rebuildUi();
+  }
+}

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
@@ -1,5 +1,6 @@
 import 'package:glass_down_v2/app/app.locator.dart';
 import 'package:glass_down_v2/services/settings_service.dart';
+import 'package:shizuku_apk_installer/shizuku_apk_installer.dart';
 import 'package:stacked/stacked.dart';
 
 class ShizukuInstallerModel extends BaseViewModel {
@@ -11,14 +12,34 @@ class ShizukuInstallerModel extends BaseViewModel {
   String? get status => _status;
 
   Future<void> checkShizukuStatus() async {
-    _status = await _settings.checkShizukuStatus();
+    _status = await ShizukuApkInstaller.checkPermission();
     rebuildUi();
   }
 
   String getStatus() {
     const description = 'Install APKs without interaction';
     final status = 'Status: $_status';
-    return '$description\n$status';
+    String message = '';
+    switch (_status) {
+      case 'binder_not_found':
+        message =
+            'Shizuku binder not found, probably because Shizuku is not installed';
+        break;
+      case 'old_shizuku':
+        message = 'Old Shizuku version (Android <11), user must update it';
+      case 'granted_adb':
+        message = 'Permission granted with ADB access';
+      case 'granted_root':
+        message = 'Permission granted with root access';
+      case 'denied':
+        message = 'Permission denied by user';
+      case 'old_android_with_adb':
+        message =
+            'Unsupported, Shizuku running on Android < 8.1 with ADB, user must update Android or use root method';
+      default:
+        message = 'Invalid status';
+    }
+    return '$description\n$status\n$message';
   }
 
   void updateValue(bool value) {

--- a/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
+++ b/lib/ui/views/settings/items/shizuku_installer/shizuku_installer_model.dart
@@ -1,5 +1,7 @@
+import 'package:flutter_logs/flutter_logs.dart';
 import 'package:glass_down_v2/app/app.locator.dart';
 import 'package:glass_down_v2/services/settings_service.dart';
+import 'package:glass_down_v2/util/function_name.dart';
 import 'package:shizuku_apk_installer/shizuku_apk_installer.dart';
 import 'package:stacked/stacked.dart';
 
@@ -11,7 +13,7 @@ class ShizukuInstallerModel extends BaseViewModel {
   String? _status;
   String? get status => _status;
 
-  bool get shizukuAvailable {
+  bool shizukuAvailable() {
     if (_status != null) {
       if (!_status!.contains('binder_not_found')) {
         return true;
@@ -22,40 +24,13 @@ class ShizukuInstallerModel extends BaseViewModel {
     return false;
   }
 
-  Future<void> checkShizukuStatus() async {
-    _status = await ShizukuApkInstaller.checkPermission();
-    rebuildUi();
-  }
-
-  String getStatus() {
-    const description = 'Install APKs without interaction';
-    final status = 'Status: $_status';
-    String message = '';
-    switch (_status) {
-      case 'binder_not_found':
-        message =
-            'Shizuku binder not found, probably because Shizuku is not installed';
-        break;
-      case 'old_shizuku':
-        message = 'Old Shizuku version (Android <11), user must update it';
-      case 'granted_adb':
-        message = 'Permission granted with ADB access';
-      case 'granted_root':
-        message = 'Permission granted with root access';
-      case 'denied':
-        message = 'Permission denied by user';
-      case 'old_android_with_adb':
-        message =
-            'Unsupported, Shizuku running on Android < 8.1 with ADB, user must update Android or use root method';
-      default:
-        message = 'Invalid status';
-    }
-    return '$description\n$status\n$message';
-  }
-
   Future<void> updateValue(bool value) async {
     _status = await ShizukuApkInstaller.checkPermission();
-    print(status);
+    FlutterLogs.logInfo(
+      runtimeType.toString(),
+      getFunctionName(),
+      'Shizuku status: ${_status ?? 'invalid'}',
+    );
     if (_status != null) {
       if (_status!.contains('granted')) {
         _settings.setShizuku(value);

--- a/lib/ui/views/settings/items/show_permissions/show_permissions.dart
+++ b/lib/ui/views/settings/items/show_permissions/show_permissions.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:glass_down_v2/ui/widgets/settings/common/item_wrapper.dart';
+import 'package:stacked/stacked.dart';
+
+import 'show_permissions_model.dart';
+
+class ShowPermissions extends StackedView<ShowPermissionsModel> {
+  const ShowPermissions({super.key});
+
+  @override
+  Widget builder(
+    BuildContext context,
+    ShowPermissionsModel viewModel,
+    Widget? child,
+  ) {
+    return InkWell(
+      onTap: () => viewModel.showPermissionsPage(),
+      child: const ItemWrapper(
+        mainText: 'Show permissions page',
+      ),
+    );
+  }
+
+  @override
+  ShowPermissionsModel viewModelBuilder(
+    BuildContext context,
+  ) =>
+      ShowPermissionsModel();
+}

--- a/lib/ui/views/settings/items/show_permissions/show_permissions_model.dart
+++ b/lib/ui/views/settings/items/show_permissions/show_permissions_model.dart
@@ -1,0 +1,12 @@
+import 'package:glass_down_v2/app/app.locator.dart';
+import 'package:glass_down_v2/ui/views/permissions/permissions_view.dart';
+import 'package:stacked/stacked.dart';
+import 'package:stacked_services/stacked_services.dart';
+
+class ShowPermissionsModel extends BaseViewModel {
+  final _navigation = locator<NavigationService>();
+
+  void showPermissionsPage() {
+    _navigation.navigateWithTransition(const PermissionsView());
+  }
+}

--- a/lib/ui/views/settings/settings_view.dart
+++ b/lib/ui/views/settings/settings_view.dart
@@ -18,6 +18,7 @@ import 'package:glass_down_v2/ui/views/settings/items/import_font/import_font.da
 import 'package:glass_down_v2/ui/views/settings/items/monet_theme/monet_theme.dart';
 import 'package:glass_down_v2/ui/views/settings/items/offer_deleting_old_apks/offer_deleting_old_apks.dart';
 import 'package:glass_down_v2/ui/views/settings/items/pages_count/pages_count.dart';
+import 'package:glass_down_v2/ui/views/settings/items/shizuku_installer/shizuku_installer.dart';
 import 'package:glass_down_v2/ui/views/settings/items/show_logs/show_logs.dart';
 import 'package:glass_down_v2/ui/widgets/common/divider.dart';
 import 'package:glass_down_v2/ui/widgets/settings/common/group_header.dart';
@@ -82,6 +83,7 @@ class SettingsView extends StackedView<SettingsViewModel> {
                   DeleteLogs(),
                   ItemDivider(),
                   GroupHeader(name: 'About'),
+                  ShizukuInstaller(),
                   CheckUpdates(),
                   AboutApp(),
                 ],

--- a/lib/ui/views/settings/settings_view.dart
+++ b/lib/ui/views/settings/settings_view.dart
@@ -20,6 +20,7 @@ import 'package:glass_down_v2/ui/views/settings/items/offer_deleting_old_apks/of
 import 'package:glass_down_v2/ui/views/settings/items/pages_count/pages_count.dart';
 import 'package:glass_down_v2/ui/views/settings/items/shizuku_installer/shizuku_installer.dart';
 import 'package:glass_down_v2/ui/views/settings/items/show_logs/show_logs.dart';
+import 'package:glass_down_v2/ui/views/settings/items/show_permissions/show_permissions.dart';
 import 'package:glass_down_v2/ui/widgets/common/divider.dart';
 import 'package:glass_down_v2/ui/widgets/settings/common/group_header.dart';
 import 'package:stacked/stacked.dart';
@@ -83,6 +84,7 @@ class SettingsView extends StackedView<SettingsViewModel> {
                   DeleteLogs(),
                   ItemDivider(),
                   GroupHeader(name: 'About'),
+                  ShowPermissions(),
                   ShizukuInstaller(),
                   CheckUpdates(),
                   AboutApp(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -258,6 +258,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.4+1"
   crypto:
     dependency: transitive
     description:
@@ -386,6 +394,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  file_picker:
+    dependency: "direct main"
+    description:
+      name: file_picker
+      sha256: "2ca051989f69d1b2ca012b2cf3ccf78c70d40144f0861ff2c063493f7c8c3d45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.5"
   fixnum:
     dependency: transitive
     description:
@@ -455,6 +471,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      sha256: c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.20"
   flutter_svg:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -118,18 +118,18 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1414d6d733a85d8ad2f1dfcb3ea7945759e35a123cb99ccfac75d0758f75edfa"
+      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.10"
+    version: "2.4.11"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "4ae8ffe5ac758da294ecf1802f2aff01558d8b1b00616aa7538ea9a8a5d50799"
+      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.0"
+    version: "7.3.1"
   built_collection:
     dependency: transitive
     description:
@@ -258,14 +258,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
-  cross_file:
-    dependency: transitive
-    description:
-      name: cross_file
-      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.4+1"
   crypto:
     dependency: transitive
     description:
@@ -394,14 +386,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
-  file_picker:
-    dependency: "direct main"
-    description:
-      name: file_picker
-      sha256: "29c90806ac5f5fb896547720b73b17ee9aed9bba540dc5d91fe29f8c5745b10a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.0.3"
   fixnum:
     dependency: transitive
     description:
@@ -459,10 +443,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_markdown
-      sha256: "9921f9deda326f8a885e202b1e35237eadfc1345239a0f6f0f1ff287e047547f"
+      sha256: ff76a9300a06ad1f2b394e54c0b4beaaf6a95f95c98540c918b870221499bb10
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.1"
+    version: "0.7.2"
   flutter_native_splash:
     dependency: "direct main"
     description:
@@ -471,14 +455,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
-  flutter_plugin_android_lifecycle:
-    dependency: transitive
-    description:
-      name: flutter_plugin_android_lifecycle
-      sha256: c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.20"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -597,10 +573,10 @@ packages:
     dependency: "direct main"
     description:
       name: internet_connection_checker_plus
-      sha256: a35278f4a8433ce254fdf115d6d25e878f58af374ad4b9713e24491d4402151d
+      sha256: "45d33532937eb931a14fb1f885c4b0ade6332983ba98349920fca0a23751d7c9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   intl:
     dependency: "direct main"
     description:
@@ -861,18 +837,18 @@ packages:
     dependency: transitive
     description:
       name: permission_handler_android
-      sha256: "8bb852cd759488893805c3161d0b2b5db55db52f773dbb014420b304055ba2c5"
+      sha256: b29a799ca03be9f999aa6c39f7de5209482d638e6f857f6b93b0875c618b7e54
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.6"
+    version: "12.0.7"
   permission_handler_apple:
     dependency: transitive
     description:
       name: permission_handler_apple
-      sha256: e9ad66020b89ff1b63908f247c2c6f931c6e62699b756ef8b3c4569350cd8662
+      sha256: e6f6d73b12438ef13e648c4ae56bd106ec60d17e90a59c4545db6781229082a0
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.4"
+    version: "9.4.5"
   permission_handler_html:
     dependency: transitive
     description:
@@ -909,10 +885,10 @@ packages:
     dependency: transitive
     description:
       name: platform
-      sha256: "12220bb4b65720483f8fa9450b4332347737cf8213dd2840d8b2c823e47243ec"
+      sha256: "9b71283fc13df574056616011fb138fd3b793ea47cc509c189a6c3fa5f8a1a65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.4"
+    version: "3.1.5"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -1098,10 +1074,10 @@ packages:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      sha256: "1e62698dc1ab396152ccaf3b3990d826244e9f3c8c39b51805f209adcd6dbea3"
+      sha256: "9f89a7e7dc36eac2035808427eba1c3fbd79e59c3a22093d8dace6d36b1fe89e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.22"
+    version: "0.5.23"
   sqlparser:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1041,6 +1041,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  shizuku_apk_installer:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: master
+      resolved-ref: "25acc02612c2e0fcae40d312e047ac48106f8f6b"
+      url: "https://github.com/re7gog/shizuku_apk_installer"
+    source: git
+    version: "0.0.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,10 @@ dependencies:
     git:
       url: https://github.com/re7gog/android_system_font
       ref: master
+  shizuku_apk_installer:
+    git:
+      url: https://github.com/re7gog/shizuku_apk_installer
+      ref: master
   file_picker: ^8.0.5
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: glass_down_v2
 description: "Simple app which allows downloading specific APK version of apps from APKMirror."
 publish_to: "none"
-version: 2.3.0-dev3
+version: 2.3.0-dev4
 
 environment:
   sdk: ">=3.0.3 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: glass_down_v2
 description: "Simple app which allows downloading specific APK version of apps from APKMirror."
 publish_to: "none"
-version: 2.3.0-dev4
+version: 2.3.0
 
 environment:
   sdk: ">=3.0.3 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: glass_down_v2
 description: "Simple app which allows downloading specific APK version of apps from APKMirror."
 publish_to: "none"
-version: 2.3.0-dev1
+version: 2.3.0-dev2
 
 environment:
   sdk: ">=3.0.3 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
     git:
       url: https://github.com/re7gog/android_system_font
       ref: master
+  file_picker: ^8.0.5
 
 dev_dependencies:
   build_runner: ^2.4.11

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: glass_down_v2
 description: "Simple app which allows downloading specific APK version of apps from APKMirror."
 publish_to: "none"
-version: 2.3.0-dev2
+version: 2.3.0-dev3
 
 environment:
   sdk: ">=3.0.3 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: glass_down_v2
 description: "Simple app which allows downloading specific APK version of apps from APKMirror."
 publish_to: "none"
-version: 2.2.2
+version: 2.3.0-dev1
 
 environment:
   sdk: ">=3.0.3 <4.0.0"
@@ -14,16 +14,15 @@ dependencies:
   device_info_plus: ^10.1.0
   dio: ^5.4.3+1
   dynamic_color: ^1.7.0
-  file_picker: ^8.0.3
   flutter:
     sdk: flutter
   flutter_archive: ^6.0.3
   flutter_logs: ^2.1.12
-  flutter_markdown: ^0.7.1
+  flutter_markdown: ^0.7.2
   flutter_native_splash: ^2.4.0
   google_fonts: ^6.2.1
   html: ^0.15.4
-  internet_connection_checker_plus: ^2.4.1
+  internet_connection_checker_plus: ^2.4.2
   intl: ^0.19.0
   open_filex: ^4.4.0
   package_info_plus: ^8.0.0
@@ -34,7 +33,7 @@ dependencies:
   stacked: ^3.4.2
   stacked_services: ^1.5.0
   drift: ^2.18.0
-  sqlite3_flutter_libs: ^0.5.22
+  sqlite3_flutter_libs: ^0.5.23
   sqlite3: ^2.4.3
   flutter_svg: ^2.0.10+1
   device_apps: ^2.2.0
@@ -44,7 +43,7 @@ dependencies:
       ref: master
 
 dev_dependencies:
-  build_runner: ^2.4.10
+  build_runner: ^2.4.11
   flutter_test:
     sdk: flutter
   flutter_lints: ^4.0.0


### PR DESCRIPTION
This release contains many changes, most of them are coming from wonderful Reddit users from Revanced Extended community :) Please read the changes below to avoid surprises when you update.

## Changes:
- Update Flutter & dependencies
- Fix: Exclude beta versions from app search
  - This will remove apps which have "beta" in name when searching for an app to add, thanks for suggestion @Welson_Liong!
- Added Shizuku support
  - Allows for unattended installation of downloaded APKs
  - Apps asks for permission first time you run it
  - Can be also enabled in Settings
  - Thanks to @__Meliante for bringing that feature to my attention
- App's permissions rework
  - Now all permissions, which were previously obligatory, are optional
  - This comes with a limitation => denying managing all files permission disallows changing the path where logs, app list export as well as downloaded APKs are stored. It will be locked to the default location (Downloads/GlassDown)
  - Denying installing packages permission will disable installation of APKs from Downloads screen, but if Shizuku is enabled in Settings, it will be used as an installation method
  - App updater will save new GlassDown version to the directory where other downloaded APKs are stored, if install packages permission is denied
  - If you have set up different directory for saving APKs than the default one you'll have an error when downloading new APK => reset app's data or enable permission to manage all files, change saving directory to default one and disable permission afterwards
- Fix: tile color where progress bar is displayed in Updater screen
- Feature: Spoof User Agent header of HTTP client to browser
- Feature: Change status of install button in Downloads view when installing APK via Shizuku to show user that APK is installing
- Feature: Add Shizuku settings tile to Quick Settings